### PR TITLE
Fix nil pointer panic on HTTP errors

### DIFF
--- a/transports/http.go
+++ b/transports/http.go
@@ -216,7 +216,7 @@ func (h *TransportHTTP) doHTTPRequest(ctx context.Context, method string, path s
 
 	var resp *http.Response
 	defer func() {
-		if resp.Body != nil {
+		if resp != nil && resp.Body != nil {
 			_ = resp.Body.Close()
 		}
 	}()


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x947135]

goroutine 105 [running]:
github.com/GorillaPool/go-junglebus/transports.(*TransportHTTP).doHTTPJsonRequest.func1()
	/root/go/pkg/mod/github.com/!gorilla!pool/go-junglebus@v0.3.0-alpha/transports/http.go:316 +0x15
github.com/GorillaPool/go-junglebus/transports.(*TransportHTTP).doHTTPJsonRequest(0xc0000b67d0, {0xf03cc0, 0x14c8cc0}, {0xc72e87, 0x3}, {0xc7afe0, 0x11}, {0x0, 0x0, 0x0}, ...)
	/root/go/pkg/mod/github.com/!gorilla!pool/go-junglebus@v0.3.0-alpha/transports/http.go:321 +0x68d
github.com/GorillaPool/go-junglebus/transports.(*TransportHTTP).GetChaintip(0xc0000b67d0, {0xf03cc0, 0x14c8cc0})
	/root/go/pkg/mod/github.com/!gorilla!pool/go-junglebus@v0.3.0-alpha/transports/http.go:251 +0x94
github.com/GorillaPool/go-junglebus.(*Client).GetChaintip(...)
	/root/go/pkg/mod/github.com/!gorilla!pool/go-junglebus@v0.3.0-alpha/blockheader.go:20
github.com/BitcoinSchema/go-bap-indexer/server.Start.func1()
	/app/server/server.go:54 +0x8c
created by github.com/BitcoinSchema/go-bap-indexer/server.Start in goroutine 70
	/app/server/server.go:51 +0x3a7
container event container died
```